### PR TITLE
feat: add gruvbox dark theme

### DIFF
--- a/src/themes.json
+++ b/src/themes.json
@@ -26,6 +26,7 @@
 	"GitHub": "#F5F7F9,#24292E,#FFFFFF,#24292E,#0366D6,#ffffff",
 	"GitHub Desktop": "#222528,#FFFFFF,#1C1E21,#FFFFFF,#0366D6,#FFFFFF",
 	"Github Dark": "#06090f,#f0f6fc,#0d1117,#c9d1d9,#238636,#ffffff",
+	"Gruvbox Dark": "#282828,#ebdbb2,#3c3836,#d5c4a1,#98971a,#282828",
 	"High Contrast Dark": "#000000,#FFFFFF,#050505,#FFFF00,#0000FF,#FFFFFF",
 	"High Contrast Light": "#FFFFFF,#000000,#FFFFFF,#000000,#0000FF,#FFFFFF",
 	"Hyst": "#000A02,#CCCCCC,#000A02,#888888,#039917,#FFFFFF",


### PR DESCRIPTION
Adds _a_ gruvbox dark theme, adapted from https://github.com/morhetz/gruvbox

I opted to use a green as the accent color.
